### PR TITLE
Update 02_import.rb

### DIFF
--- a/lib/zci/commands/02_import.rb
+++ b/lib/zci/commands/02_import.rb
@@ -85,7 +85,7 @@ command :'import:sources' do |c|
         {
           source:         File.join(resources_category_dir, file_name),
           dest:           File.join(source_category_id.to_s, file_name),
-          export_pattern: '/%two_letters_code%/%original_path%/%original_file_name%',
+          export_pattern: '/%locale%/%original_path%/%original_file_name%',
           title:          category_hash[:name]
         }
       ]
@@ -110,7 +110,7 @@ command :'import:sources' do |c|
           {
             source:         File.join(resources_category_dir, file_name),
             dest:           File.join(source_category_id.to_s, file_name),
-            export_pattern: '/%two_letters_code%/%original_path%/%original_file_name%',
+            export_pattern: '/%locale%/%original_path%/%original_file_name%',
             title:          section[:name]
           }
         ]
@@ -136,7 +136,7 @@ command :'import:sources' do |c|
           {
             source:         File.join(resources_category_dir, file_name),
             dest:           File.join(source_category_id.to_s, file_name),
-            export_pattern: '/%two_letters_code%/%original_path%/%original_file_name%',
+            export_pattern: '/%locale%/%original_path%/%original_file_name%',
             title:          article[:title]
           }
         ]


### PR DESCRIPTION
It should be better to use `%locale%` for exported files. If `%two_letters_code%` is used, then both Chinese Traditional and Chinese Simplified are exported as `zh` from Crowdin, so one language will overwrite another on export.