### PR TITLE
patch export command

### DIFF
--- a/lib/zci/commands/04_export.rb
+++ b/lib/zci/commands/04_export.rb
@@ -20,7 +20,7 @@ command :'export:translations' do |c|
     crowdin_supported_languages = @crowdin.supported_languages
 
     @cli_config['categories'].each do |category_section|
-      zendesk_url = category.fetch('brand_url', @cli_config['zendesk_base_url'])
+      zendesk_url = category_section.fetch('brand_url', @cli_config['zendesk_base_url'])
 
       zendesk_client = ZCI.initialize_zendesk_client(
         zendesk_url,


### PR DESCRIPTION
Hi, Thank you for creating a great integration tool.
I saw an error of missing a variable. This command can't run the `export:translations` command currently.

Could you take a look?
Thanks,