### PR TITLE
use environment valiables in yaml config

### DIFF
--- a/bin/zci
+++ b/bin/zci
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 require 'gli'
 require 'zci'
+require 'erb'
 
 include GLI::App
 include ZCI
@@ -40,7 +41,7 @@ pre do |global, command, options, args|
 
   # load project-specific configuration
   begin
-    @cli_config = YAML.load(File.read(global[:config])) || {}
+    @cli_config = YAML.load(ERB.new(File.read(global[:config])).result) || {}
   rescue Psych::SyntaxError => err
     exit_now! <<-EOS
       Could not parse YAML: #{err.message}


### PR DESCRIPTION
This change is about using environment variables in yaml config. We can use system env like this.
Could you look at it?

```
crowdin_project_id: <%= ENV["CROWDIN_PROJECT_ID"] %>
crowdin_api_key: <%= ENV["CROWDIN_API_KEY"] %>
```